### PR TITLE
Personalize About section and align site messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,7 @@
             <div class="max-w-5xl mx-auto px-4 text-center">
                 <span class="inline-block px-4 py-2 bg-blue-100 text-blue-600 rounded-full text-sm font-semibold mb-6" x-text="content.about.title"></span>
                 <h2 class="text-4xl md:text-5xl font-bold text-gray-900 mb-8">
-                    Innovation Meets <span class="text-gradient">Excellence</span>
+                    Passion Meets <span class="text-gradient">Purpose</span>
                 </h2>
                 <template x-for="para in content.about.text">
                     <p class="text-xl text-gray-600 mb-6 leading-relaxed" x-text="para"></p>
@@ -329,12 +329,12 @@
         <section id="solutions" class="py-24 bg-white">
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="text-center mb-16">
-                    <span class="inline-block px-4 py-2 bg-blue-100 text-blue-600 rounded-full text-sm font-semibold mb-6">Our Solutions</span>
+                    <span class="inline-block px-4 py-2 bg-blue-100 text-blue-600 rounded-full text-sm font-semibold mb-6">AppExchange Apps</span>
                     <h2 class="text-4xl md:text-5xl font-bold text-gray-900 mb-6">
                         Powerful Apps for <span class="text-gradient">Salesforce</span>
                     </h2>
                     <p class="text-xl text-gray-600 max-w-3xl mx-auto">
-                        Discover our suite of innovative AppExchange solutions designed to enhance your Salesforce experience
+                        Free, innovative AppExchange apps designed to enhance your Salesforce experience
                     </p>
                 </div>
 
@@ -476,7 +476,7 @@
                 </form>
 
                 <p class="mt-8 text-center text-gray-600">
-                    Or email us directly at:
+                    Or email directly at:
                     <a :href="'mailto:' + content.contact.supportEmail" class="text-blue-600 hover:text-blue-700 font-semibold hover:underline" x-text="content.contact.supportEmail"></a>
                 </p>
             </div>
@@ -492,7 +492,7 @@
                         <img src="images/logo.png" alt="TactForce Logo" class="w-12 h-12 object-contain" onerror="this.style.display='none'">
                         <span class="text-xl font-bold text-white">TactForce</span>
                     </div>
-                    <p class="text-gray-400">Building innovative Salesforce solutions for tomorrow's challenges.</p>
+                    <p class="text-gray-400">Building free Salesforce apps, one solution at a time.</p>
                 </div>
 
                 <div>

--- a/index.html
+++ b/index.html
@@ -509,6 +509,14 @@
                     <a :href="content.footer.buyMeCoffeeLink" target="_blank" class="inline-block transition-transform hover:scale-105">
                         <img :src="content.footer.buyMeCoffeeImage" alt="Buy Me A Coffee" class="h-12">
                     </a>
+                    <div class="mt-4">
+                        <a :href="content.footer.linkedInLink" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 text-gray-400 hover:text-white transition-colors duration-200">
+                            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+                            </svg>
+                            <span class="text-sm">Connect on LinkedIn</span>
+                        </a>
+                    </div>
                 </div>
             </div>
 

--- a/js/content.js
+++ b/js/content.js
@@ -19,14 +19,14 @@ window.siteContent = {
     ],
     "hero": {
         "title": "Expert Salesforce Solutions",
-        "subtitle": "Elevate your Salesforce experience with powerful AppExchange apps built by Bobby, a proud Salesforce Partner.",
+        "subtitle": "Elevate your Salesforce experience with powerful AppExchange apps developed by TactForce, a proud Salesforce Partner.",
         "cta": "Explore the Apps",
         "ctaLink": "#solutions"
     },
     "about": {
         "title": "About",
         "text": [
-            "Hi, I'm Bobby — a Salesforce Architect with a passion for building tools that make life easier for admins and developers.",
+            "I'm a Salesforce Architect & Developer with a passion for building tools that make life easier for admins and developers.",
             "TactForce is my way of giving back to the Salesforce community. Every app I publish on the AppExchange is free, built with care, and backed by my commitment as a registered Salesforce Partner."
         ]
     },
@@ -100,7 +100,8 @@ window.siteContent = {
     "footer": {
         "copyright": "© 2025 TactForce. All Rights Reserved.",
         "buyMeCoffeeLink": "https://www.buymeacoffee.com/BhanuVakati",
-        "buyMeCoffeeImage": "https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png"
+        "buyMeCoffeeImage": "https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png",
+        "linkedInLink": "https://www.linkedin.com/in/bhanuprakashvakati/"
     },
     "guides": {
         "dynamic-path": {

--- a/js/content.js
+++ b/js/content.js
@@ -19,15 +19,15 @@ window.siteContent = {
     ],
     "hero": {
         "title": "Expert Salesforce Solutions",
-        "subtitle": "Elevate your Salesforce experience with powerful AppExchange apps developed by TactForce, a proud Salesforce Partner.",
-        "cta": "Explore Our Solutions",
+        "subtitle": "Elevate your Salesforce experience with powerful AppExchange apps built by Bobby, a proud Salesforce Partner.",
+        "cta": "Explore the Apps",
         "ctaLink": "#solutions"
     },
     "about": {
-        "title": "About Us",
+        "title": "About",
         "text": [
-            "We are dedicated Salesforce professionals focused on creating innovative solutions that solve real business challenges within the Salesforce ecosystem.",
-            "As a registered Salesforce Partner, we adhere to the highest standards of development and customer success."
+            "Hi, I'm Bobby — a Salesforce Architect with a passion for building tools that make life easier for admins and developers.",
+            "TactForce is my way of giving back to the Salesforce community. Every app I publish on the AppExchange is free, built with care, and backed by my commitment as a registered Salesforce Partner."
         ]
     },
     "products": [
@@ -66,14 +66,14 @@ window.siteContent = {
         }
     ],
     "features": {
-        "title": "Why Choose Us",
+        "title": "Why TactForce",
         "heading": "Built for Success",
         "items": [
             {
                 "icon": "zap",
                 "iconColor": "blue",
                 "title": "Lightning Fast",
-                "description": "Built with performance in mind, our solutions deliver lightning-fast results without compromising functionality."
+                "description": "Built with performance in mind, every app delivers lightning-fast results without compromising functionality."
             },
             {
                 "icon": "shield-check",
@@ -91,7 +91,7 @@ window.siteContent = {
     },
     "contact": {
         "title": "Get In Touch",
-        "subtitle": "Have questions about our solutions, need support, or interested in custom development? Contact us!",
+        "subtitle": "Have questions about an app, need support, or just want to say hi? I'd love to hear from you.",
         "formAction": "https://webto.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8&orgId=00Dau000004vwBR",
         "orgId": "00Dau000004vwBR",
         "retURL": "tactforce.ca",


### PR DESCRIPTION
## Summary

- **About section**: Replaced generic team copy with a personal first-person intro ("I'm a Salesforce Architect & Developer...") and updated heading to "Passion Meets Purpose"
- **Messaging consistency**: Removed "we/our" language across hero CTA, features, contact, solutions, and footer to match solo developer reality — TactForce brand name kept intact throughout
- **LinkedIn**: Added LinkedIn profile link + icon to footer alongside Buy Me a Coffee

## Changes

| File | What changed |
|---|---|
| `js/content.js` | About title/text, hero CTA, features title & description, contact subtitle, footer LinkedIn link |
| `index.html` | Solutions badge, solutions description, about heading, footer tagline, LinkedIn icon in footer |

https://claude.ai/code/session_01KJYsXj6JgtEsYLYk7hpweT